### PR TITLE
support MFLAG=-ML for vc2003 complier

### DIFF
--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -8,6 +8,8 @@
 #         OBJA="inffas32.obj match686.obj"               (use ASM code, x86)
 #   nmake -f win32/Makefile.msc AS=ml64 LOC="-DASMV -DASMINF -I." \
 #         OBJA="inffasx64.obj gvmat64.obj inffas8664.obj"  (use ASM code, x64)
+#   nmake -f win32/Makefile.msc MFLAGS=-ML
+#         MFLAGS=-ML                                     (no msvcr with VC2003)
 
 # The toplevel directory of the source tree.
 #
@@ -21,12 +23,16 @@ STATICLIB = zlib_a.lib
 SHAREDLIB = zlib.dll
 IMPLIB    = zdll.lib
 
+!if !defined(MFLAGS)
+MFLAGS=-MD
+!endif
+
 CC = cl
 AS = ml
 LD = link
 AR = lib
 RC = rc
-CFLAGS  = -nologo -MD -W3 -O2 -Oy- -Zi -Fd"zlib" $(LOC)
+CFLAGS  = -nologo -W3 -O2 -Oy- -Zi -Fd"zlib" $(LOC) $(MFLAGS)
 WFLAGS  = -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
 ASFLAGS = -coff -Zi $(LOC)
 LDFLAGS = -nologo -debug -incremental:no -opt:ref


### PR DESCRIPTION
Let zlib.dll has no msvcr70.dll depends. Working in vc2003 compiler only.